### PR TITLE
Attachment addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ If you wish to contribute please follow the conventions used so far, make a new 
 
 ~~Install with NPM~~
 
+Clone the repo so that you get the post functionality that can handle attachment sending to JIRA.
+
 In your application, require the library using
 
 	var jira = require('jira-api');

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can add an attachment to an existing issue
                     key: "PROJ999-100"
                 }       
             },          
-            file: './images/awesome-kirk2.jpg'
+            file: "./images/awesome-kirk2.jpg"
         }               
 	};
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ If you wish to contribute please follow the conventions used so far, make a new 
 # Installation
 
 ~~Install with NPM~~
-~~npm install jira-api~~
 
 In your application, require the library using
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ You can add an attachment to an existing issue
         }               
 	};
 
-	jira.issue.post(options, function(response) {
-		console.log(JSON.stringify(response, null, 4));
+	jira.issue.post(options, function(err, response) {
+		if (err)
+			console.error(err);
+		else
+			console.log(JSON.stringify(response, null, 4));
 	});
 
 For a list of available request representations consult the [official API documentation](http://docs.atlassian.com/jira/REST/latest/).

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ If you wish to contribute please follow the conventions used so far, make a new 
 # Installation
 
 ~~Install with NPM~~
-
-	~~npm install jira-api~~
+~~npm install jira-api~~
 
 In your application, require the library using
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In your application, require the library using
 
 # Usage
 
+## Get issue information
 Now you're ready to make calls to the API
 
 	var options = {
@@ -35,6 +36,7 @@ Now you're ready to make calls to the API
 		console.log(JSON.stringify(response, null, 4));
 	});
 
+## Create an issue
 You can also specify the data to send (in case of POST, PUT etc.)
 
 	var options = {
@@ -61,6 +63,30 @@ You can also specify the data to send (in case of POST, PUT etc.)
 				}
 			}
 		}
+	};
+
+	jira.issue.post(options, function(response) {
+		console.log(JSON.stringify(response, null, 4));
+	});
+
+
+## Add an attachment
+You can add an attachment to an existing issue 
+
+	var options = {
+		config: {
+			"username": "someuser",
+			"passowrd": "secretpass",
+			"host": "example.com/jira/"
+		},
+        data: {         
+            fields: {   
+                issue: {
+                    key: "PROJ999-100"
+                }       
+            },          
+            file: './images/awesome-kirk2.jpg'
+        }               
 	};
 
 	jira.issue.post(options, function(response) {

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ If you wish to contribute please follow the conventions used so far, make a new 
 
 # Installation
 
-Install with NPM
+~~Install with NPM~~
 
-	npm install jira-api
+	~~npm install jira-api~~
 
 In your application, require the library using
 

--- a/lib/issue/index.js
+++ b/lib/issue/index.js
@@ -1,4 +1,8 @@
-var https = require('https');
+var https = require('https'),
+	mime = require('mime'),
+	path = require('path'),
+	fs = require('fs'),
+    async = require('async');
 
 exports.createmeta = require('./createmeta');
 
@@ -9,61 +13,140 @@ exports.createmeta = require('./createmeta');
  * @param  Function {callback} the function to execute on success
  */
 exports.post = function(options, callback) {
+	var boundary = '----------------------------' + Date.now(),
+	    payload = {
+            head: '',
+            data: '',
+            tail: '',
+            length: 0
+        };
 
 	/*
-	 * Building the request parmeters
+	 * Write the payload for the request
 	 */
-	var params = {
-		method: 'POST',
-		host: options.config.host,
-		path: '/rest/api/2/issue/',
-		auth: options.config.username + ':' + options.config.password,
-		headers: {
-			'content-type': 'application/json',
-			'content-length': Buffer.byteLength(JSON.stringify(options.data)),
-			'accept': 'application/json'
+	function setPayload(callback) {
+        if (options.data.file != undefined) {
+            async.waterfall([
+                // Head
+                function (callback) {
+                    payload.head = new Buffer('--' + boundary + '\r\n' + 
+                        'Content-Disposition: form-data; name="file"; filename="' + path.basename(options.data.file) + '"\r\n' +
+                        'Content-Type: ' + mime.lookup(options.data.file) + '\r\n' + 
+                        '\r\n');
+                    callback(null);
+                },
+                // Body
+                function (callback) {
+                    fs.readFile(options.data.file, function (err, data) {
+                        payload.data = data;
+                        callback(null);
+                    });
+                },
+                // Tail
+                function (callback) {
+                    payload.tail = new Buffer('\r\n--' + boundary + '--\r\n\r\n');
+                    callback(null);
+                },
+                // Length 
+                function (callback) {
+                    payload.length = payload.head.length + payload.data.length + payload.tail.length;
+                    callback(null);
+                }
+            ],
+            // Result
+            function (err) {
+                if (err) 
+                    callback(err);
+                else 
+                    callback(null);
+            });
+        }
+        else {
+            payload.data = JSON.stringify(options.data);
+            payload.length = payload.data.length;
+            callback(null);
+        }
+	}
+
+    /* 
+     * Build the request parameters and headers
+     */
+	function buildRequestParams(callback) {
+        var params = {
+            method: 'POST',
+            host: config.jira.host,
+            auth: config.jira.username + ':' + config.jira.password,
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': payload.length
+            }
+        }
+
+		if (options.data.file != undefined) {
+            params.headers = {
+                'Content-Type': 'multipart/form-data; boundary=' + boundary,
+                'X-Atlassian-Token': 'nocheck',
+                'Content-Length': payload.length
+            }
+            params.path = config.jira.path + '/issue/' + options.data.fields.issue.key + '/attachments',
+
+            callback(null, params);
 		}
-	};
+		else {
+            params.path = config.jira.path + '/issue/';
 
-	/*
-	 * The response body will fill this variable
-	 */
-	var body = '';
+			callback(null, params);
+		}
+	}
 
-	/*
-	 * Now lets make the actual request
-	 */
-	var request = https.request(params, function(response) {
+    /* 
+     * Send the request and get a response
+     */
+    function sendRequest(params, callback) {
+        var responseBody = '',
+            request;
 
-		/*
-		 * Append returned chunks of data to body variable
-		 */
-		response.on('data', function(chunk) {
-			body += chunk;
-		});
+        request = https.request(params, function(response) {
+            response.on('data', function (chunk) {
+                responseBody += chunk;
+            });
 
-		/*
-		 * When connection closes execute the callers callback function
-		 */
-		response.on('end', function() {
-			callback(JSON.parse(body));
-		});
+            response.on('end', function () {
+                try {
+                    callback(null, JSON.parse(responseBody)); }
+                catch (e) {
+                    callback(null, responseBody); }
+            });
 
-		/*
-		 * Show any errors that occured during the request
-		 */
-		response.on('error', function(e) {
-			console.error(e);
-		});
-
-	});
-
-	/*
-	 * Write the body of the request with the data suplied by the caller
-	 */
-	request.write(JSON.stringify(options.data));
-
-	request.end();
+            response.on('error', function (err) {
+                callback(err, null);
+            });
+        });
+            
+        request.write(payload.head);
+        request.write(payload.data);
+        request.write(payload.tail);
+        request.end();
+    }
+	
+    setPayload(function(err) {
+        if (err)
+            callback(err, null);
+        else {
+            buildRequestParams(function (err, params) {
+                if (err)
+                    callback(err, null);
+                else {
+                    sendRequest(params, function (err, response) {
+                        if (err)
+                            callback(err, null);
+                        else
+                            callback(null, response);
+                    });
+                }
+            });
+        }
+    });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
         "jira",
         "JIRA"
     ],
+    "dependencies": {
+        "mime": ">=1.2.7",
+        "async": ">=0.1.22",
+        "path": ">=0.4.9"
+    },
     "license": "Apache License, Version 2.0",
     "main": "./lib/index.js"
 }


### PR DESCRIPTION
Hi,

I've added some code to extend on your API work. It allows an attachment to be posted (via REST) to an existing JIRA issue via multipart. We use it at Klarna.com along with Selenium and Zephyr to grab a screenshot from failed testcases and automatically create a JIRA defect.

Thanks,
Conor
